### PR TITLE
Test FullSanitizer

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,6 +8,7 @@ class ArticlesController < ApplicationController
   def show
     @article = Article.find(params[:id])
     authorize @article
+    @article.body = Rails::Html::FullSanitizer.new.sanitize(@article.body)
   end
 
   def new

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -9,3 +9,5 @@
                     turbo_confirm: "Are you sure?"
                   } %></li>
 </ul>
+
+<!-- or here <p><%= Rails::Html::FullSanitizer.new.sanitize(@article.body) %></p> -->


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc194430-2df9-4cca-8fd2-9d893ba64a7a)

with
![image](https://github.com/user-attachments/assets/7ed3215f-29cb-4f77-8648-965010c4f940)

without
![image](https://github.com/user-attachments/assets/4d8a9c8f-7e6f-4eb6-b9c1-6d7f62a33c9d)

in both case we're safe

----

using sanitize only secure the situation where default escaping in erb is disabled:
- `<p><%== @article.body %></p>`

or disabled in slim:
- `== article.body`
